### PR TITLE
chore(deps): update minitest and activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -66,7 +66,7 @@ GEM
     lumberjack (1.4.2)
     method_source (1.1.0)
     mini_portile2 (2.8.9)
-    minitest (6.0.2)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     mutex_m (0.3.0)


### PR DESCRIPTION
## Summary
- Bump transitive deps: minitest 6.0.2→6.0.6, activesupport 8.1.2→8.1.3
- Resolves Dependabot update job failures where it couldn't unlock these subdependencies

Refs unhappychoice/oss-issue-opener#159

## Test plan
- [x] `bundle check` passes